### PR TITLE
Replace `kotlin-stdlib-jdk8` with `kotlin-stdlib`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     implementation("com.github.ben-manes.caffeine:caffeine:3.1.2")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 


### PR DESCRIPTION
Kotlin 1.8.0 dropped support for Java 1.6 and 1.7 and therefore all artifacts are now merged:https://kotlinlang.org/docs/whatsnew18.html#updated-jvm-compilation-target