### PR TITLE
feat: add page with link to 404 error page

### DIFF
--- a/src/main/resources/static/error-link.html
+++ b/src/main/resources/static/error-link.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Error Links</title>
+    <link href="img/vividus.png" type="image/png">
+</head>
+<body>
+    <h1>404 link</h1>
+    <a href="/404-test-link">Link to 404 page</a>
+    <br>
+</body>
+</html>

--- a/src/main/resources/static/error-link.html
+++ b/src/main/resources/static/error-link.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <title>Error Links</title>
-    <link href="img/vividus.png" type="image/png">
 </head>
 <body>
     <h1>404 link</h1>


### PR DESCRIPTION
Created html page with link to https://www.google.com/some-broken-link.html which lead to 404 error page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Error Links” page with a 404 heading.
  * Added a link to a test 404 path for error-page scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->